### PR TITLE
Flatten the heading levels

### DIFF
--- a/app/views/month.html
+++ b/app/views/month.html
@@ -8,91 +8,96 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-xl">Statistics</span>
       <h1 class="govuk-heading-xl">
-        Initial teacher training applications data for courses starting in the 2022 to 2023 academic year
+        Initial teacher training applications for courses starting in the 2022 to 2023 academic year
       </h1>
 
-      <div class="govuk-body govuk-!-font-size-40 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</div>
+      <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</h2>
 
-      <ul class="govuk-list govuk-!-margin-bottom-8 app-toc">
+      <ol class="govuk-list govuk-!-margin-bottom-8 app-toc">
         <li>
           <a href="#introduction" class="govuk-link app-toc__link">
-            <span class="app-toc__content">What's included in this data?</span>
+            <span class="app-toc__number">1.</span>
+            <span class="app-toc__content">Introduction</span>
             </a>
         </li>
         <li>
           <a href="#data-updates" class="govuk-link app-toc__link">
+            <span class="app-toc__number">2.</span>
             <span class="app-toc__content">Data updates</span>
             </a>
         </li>
         <li>
-          <a href="#data-by-category" class="govuk-link app-toc__link">
-            <span class="app-toc__content">Data by category</span>
-            </a>
+          <a href="#applicants-by-status" class="govuk-link app-toc__link">
+            <span class="app-toc__number">3.</span>
+            <span class="app-toc__content">Candidates by application status</span>
+          </a>
         </li>
         <li>
           <a href="#applicants-by-status" class="govuk-link app-toc__link">
-            <span class="app-toc__number">1.</span>
+            <span class="app-toc__number">4.</span>
             <span class="app-toc__content">Application status</span>
           </a>
         </li>
         <li>
           <a href="#applicants-by-age-group" class="govuk-link app-toc__link">
-            <span class="app-toc__number">2.</span>
+            <span class="app-toc__number">5.</span>
             <span class="app-toc__content">Candidate age group</span>
           </a>
         </li>
         <li>
           <a href="#applicants-by-sex" class="govuk-link app-toc__link">
-            <span class="app-toc__number">3.</span>
+            <span class="app-toc__number">6.</span>
             <span class="app-toc__content">Candidate sex</span>
           </a>
         </li>
         <li>
           <a href="#applicants-by-area" class="govuk-link app-toc__link">
-            <span class="app-toc__number">4.</span>
+            <span class="app-toc__number">7.</span>
             <span class="app-toc__content">Candidate area</span>
           </a>
         </li>
         <li>
           <a href="#applications-by-course-age-group" class="govuk-link app-toc__link">
-            <span class="app-toc__number">5.</span>
+            <span class="app-toc__number">8.</span>
             <span class="app-toc__content">Course phase</span>
           </a>
         </li>
         <li>
           <a href="#applications-by-course-type" class="govuk-link app-toc__link">
-            <span class="app-toc__number">6.</span>
+            <span class="app-toc__number">9.</span>
             <span class="app-toc__content">Route into teaching</span>
           </a>
         </li>
         <li>
           <a href="#applications-by-primary-subject" class="govuk-link app-toc__link">
-            <span class="app-toc__number">7.</span>
+            <span class="app-toc__number">10.</span>
             <span class="app-toc__content">Primary specialist subject</span>
           </a>
         </li>
         <li>
           <a href="#applications-by-secondary-subject" class="govuk-link app-toc__link">
-            <span class="app-toc__number">8.</span>
+            <span class="app-toc__number">11.</span>
             <span class="app-toc__content">Secondary subject</span>
           </a>
         </li>
         <li>
           <a href="#applications-by-provider-area" class="govuk-link app-toc__link">
-            <span class="app-toc__number">9.</span>
+            <span class="app-toc__number">12.</span>
             <span class="app-toc__content">Provider region</span>
           </a>
         </li>
         <li>
           <a href="#download" class="govuk-link app-toc__link">
+            <span class="app-toc__number">13.</span>
             <span class="app-toc__content">Download the data</span>
           </a>
         </li>
-      </ul>
+      </ol>
 
 
-      <h2 class="govuk-heading-l" id="introduction">What's included in this data?</h2>
+      <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
       <p class="govuk-body">These statistics cover applications made through Apply for teacher training for courses in England starting in the 2022 to 2023 academic year.</p>
 
@@ -102,15 +107,13 @@
 
       <p class="govuk-body">Teacher training applications made directly to providers or through other services such as Teach First are not included. Undergraduate teacher training is also not included.</p>
 
-      <h2 class="govuk-heading-l" id="data-updates">Data updates</h2>
+      <h2 class="govuk-heading-l" id="data-updates">2. Data updates</h2>
 
       <p class="govuk-body">These statistics collect data from October 2021 to [x, when the data was most recently cut] (ITT2022) and include deferred applications from the October 2020 to September 2021 recruitment cycle (ITT2021).</p>
 
       <p class="govuk-body">New data for each month in the ITT2022 recruitment cycle is added monthly.</p>
 
-      <h2 class="govuk-heading-l" id="data-by-category">Data by category</h2>
-
-      <h3 class="govuk-heading-m" id="applicants-by-status">1. Application status</h3>
+      <h2 class="govuk-heading-l" id="applicants-by-status">3. Candidates by application status</h2>
 
       <p class="govuk-body">When applying for the first time in a recruitment cycle, candidates can make up to 3 applications at the same time.</p>
 
@@ -132,12 +135,12 @@
 
       <p class="govuk-body">Candidates can make one application at a time, as many times as they like, if their first set of applications do not lead to a place.</p>
 
-      <p class="govuk-body">The ‘apply again’ column of the first table below counts only the status of a candidate's most recent ‘apply again’ application. Their previous applications are not counted anywhere in the table.</p>
+      <p class="govuk-body">The ‘apply again’ column of the first table below counts only the status of a candidate’s most recent ‘apply again’ application. Their previous applications are not counted anywhere in the table.</p>
 
       <p class="govuk-body">The status of any one application changes throughout its lifecycle. Statuses are captured at the end of the data period.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Candidates by most “favourable” application status</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 3.1: Candidates by most “favourable” application status</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Status</th>
@@ -200,10 +203,12 @@
         </tfoot>
       </table>
 
+      <h2 class="govuk-heading-l" id="applicants-by-status">4. Application status</h2>
+
       <p class="govuk-body">This table counts all applications by their status.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Applications by status</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 4.1: Applications by status</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Status</th>
@@ -271,7 +276,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h3 class="govuk-heading-m" id="applicants-by-age-group">2. Candidate age group</h3>
+      <h2 class="govuk-heading-l" id="applicants-by-age-group">5. Candidate age group</h2>
 
       <p class="govuk-body">Candidate age is calculated from the date of birth they provide when applying.</p>
 
@@ -282,7 +287,7 @@
       <p class="govuk-body">This table counts all candidates by their age group.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Candidates by age group</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 4.1: Candidates by age group</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Age group</th>
@@ -431,12 +436,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h3 class="govuk-heading-m" id="applicants-by-sex">3. Candidate sex</h3>
+      <h2 class="govuk-heading-l" id="applicants-by-sex">6. Candidate sex</h2>
 
       <p class="govuk-body">This table counts all candidates by their sex, indicated by the candidate when applying.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Candidates by sex</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 5.1: Candidates by sex</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Sex</th>
@@ -503,7 +508,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m" id="applicants-by-area">4. Candidate area</h2>
+      <h2 class="govuk-heading-l" id="applicants-by-area">7. Candidate area</h2>
 
     </div>
   </div>
@@ -513,7 +518,7 @@
       <p class="govuk-body">This table counts all candidates by their UK region or country, or other area. Candidate areas are generated by the contact address they gave when applying.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Candidates by UK region or country, or other area</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 6.1: Candidates by UK region or country, or other area</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Area</th>
@@ -688,7 +693,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m" id="applications-by-course-age-group">5. Course phase</h3>
+      <h2 class="govuk-heading-l" id="applications-by-course-age-group">8. Course phase</h2>
 
     </div>
   </div>
@@ -700,7 +705,7 @@
       <p class="govuk-body">This table counts all applications by course phase.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Applications by course phase</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 7.1: Applications by course phase</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Age group</th>
@@ -764,7 +769,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m" id="applications-by-course-type">6. Route into teaching</h3>
+      <h2 class="govuk-heading-l" id="applications-by-course-type">9. Route into teaching</h2>
 
     </div>
   </div>
@@ -776,7 +781,7 @@
       <p class="govuk-body">This table counts all applications by the training route chosen.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Applications by route</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 8.1: Applications by route</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Training route</th>
@@ -854,7 +859,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m" id="applications-by-primary-subject">7. Primary specialist subject</h3>
+      <h2 class="govuk-heading-l" id="applications-by-primary-subject">10. Primary specialist subject</h2>
 
     </div>
   </div>
@@ -866,7 +871,7 @@
       <p class="govuk-body">This table counts all applications by primary specialist subject.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Applications by primary specialist subject</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Table 10.1: Applications by primary specialist subject</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Subject</th>
@@ -963,7 +968,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m" id="applications-by-secondary-subject">8. Secondary subject</h3>
+      <h2 class="govuk-heading-l" id="applications-by-secondary-subject">11. Secondary subject</h2>
 
     </div>
   </div>
@@ -975,7 +980,7 @@
       <p class="govuk-body">This table counts all applications by secondary subject. If a course has more than one subject, the main subject is counted.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Applications by secondary subject</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">11.1 Applications by secondary subject</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Subject</th>
@@ -1252,7 +1257,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m" id="applications-by-provider-area">9. Provider region</h3>
+      <h2 class="govuk-heading-l" id="applications-by-provider-area">12. Provider region</h2>
 
     </div>
   </div>
@@ -1264,7 +1269,7 @@
       <p class="govuk-body">This table counts all candidates by the area of the provider they applied to.</p>
 
       <table class="govuk-table govuk-!-font-size-16">
-        <caption class="govuk-table__caption govuk-table__caption--s">Candidates by provider region of England</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">12.1 Candidates by provider region of England</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-font-weight-regular" aria-sort="ascending">Area</th>
@@ -1387,13 +1392,13 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l" id="download">Download the data</h2>
+      <h2 class="govuk-heading-l" id="download">13. Download the data</h2>
 
       <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
       <p class="govuk-body">The downloads include some further breakdowns of the data by combining fields - for example, applicant age and sex.</p>
 
-      <p class="govuk-body">In cases where the data counts fewer than 5 candidates or applications in a particular category (for example, if age, sex and region are combined), data is marked '0 to 4'. This is to prevent anyone being identifiable by a data count.</p>
+      <p class="govuk-body">In cases where the data counts fewer than 5 candidates or applications in a particular category (for example, if age, sex and region are combined), data is marked ‘0 to 4’. This is to prevent anyone being identifiable by a data count.</p>
 
       <p class="govuk-body">
         <a href="#" class="govuk-link">


### PR DESCRIPTION
Given that the bulk of the content (the data sections) are on the same level, I think it makes sense to keep all the headings on the same level, to simplify the table of contents and structure.

This also lets us increase the font size of those headings, and the table headings (captions), which otherwise are quite small (same size as body text).

Other suggested changes:

* Remove "data" from the title and add "Statistics" as a caption before the title.  Previous research I've seen has suggested that people sometimes think of "data" as being purely raw numbers, whereas "statistics" was more approachable.
* Change the first heading to "Introduction" – felt a bit weird to me to have this be a question? Also lets us add a bit more context in future if research shows it's need (eg perhaps a quick explanation of what "initial teacher training" means)
* Move "Candidate application status" and "Application status" into separate sections. The lengthy introduction to this section only referred to the "most favourable status" table, and the "This table counts all applications by their status." paragraph in-between could be ambiguous, so separating them might make this clearer?
* Number the tables (eg "Table 1.2: ...") – follows the pattern used by [some other government statistics](https://www.gov.uk/government/statistics/poultry-and-poultry-meat-statistics/monthly-statistics-on-the-activity-of-uk-hatcheries-and-uk-poultry-slaughterhouses-data-for-january-2021#numbers-of-eggs-set-and-chicks-placed-by-uk-hatcheries) and might make it easier for users to refer to tables when referencing them from other publications?